### PR TITLE
🔧 fix: add packages write permission for Docker registry push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  packages: write
 
 env:
   NODE_VERSION: '22'


### PR DESCRIPTION
## Summary
- Adds `packages: write` permission to CI workflow to resolve Docker image push failures
- Fixes "installation not allowed to Create organization package" error in GitHub Actions

## Problem
The CI workflow was failing when trying to push Docker images to GitHub Container Registry (ghcr.io) with the error:
```
ERROR: failed to push ghcr.io/jocur/project-nexus/backend:main: denied: installation not allowed to Create organization package
```

## Solution
Added `packages: write` permission to the workflow permissions section. This allows GitHub Actions to:
- Create and push Docker images to GitHub Container Registry
- Manage organization packages in ghcr.io

## Changes Made
- Added `packages: write` to the `permissions` section in `.github/workflows/ci.yml`
- No other changes to build or deployment logic

## Test Plan
- [x] Workflow has necessary permissions to push to ghcr.io
- [x] Build step can create and push backend Docker images
- [x] Build step can create and push frontend Docker images
- [x] No impact on other CI steps or security

This is a minimal permissions fix that resolves the Docker registry push error without affecting other workflow functionality.